### PR TITLE
增加界面的定制属性

### DIFF
--- a/LeanCloudFeedback/LCUserFeedbackBaseCell.h
+++ b/LeanCloudFeedback/LCUserFeedbackBaseCell.h
@@ -1,0 +1,15 @@
+//
+//  LCUserFeedbackBaseCell.h
+//  Pods
+//
+//  Created by lzw on 15/7/17.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface LCUserFeedbackBaseCell : UITableViewCell
+
+@property (nonatomic, strong) UIFont *cellFont UI_APPEARANCE_SELECTOR;
+
+@end

--- a/LeanCloudFeedback/LCUserFeedbackBaseCell.m
+++ b/LeanCloudFeedback/LCUserFeedbackBaseCell.m
@@ -1,0 +1,23 @@
+//
+//  LCUserFeedbackBaseCell.m
+//  Pods
+//
+//  Created by lzw on 15/7/17.
+//
+//
+
+#import "LCUserFeedbackBaseCell.h"
+
+@implementation LCUserFeedbackBaseCell
+
+- (void)awakeFromNib {
+    // Initialization code
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+@end

--- a/LeanCloudFeedback/LCUserFeedbackLeftCell.h
+++ b/LeanCloudFeedback/LCUserFeedbackLeftCell.h
@@ -5,9 +5,9 @@
 //  Copyright (c) 2014 LeanCloud. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import "LCUserFeedbackBaseCell.h"
 
-@interface LCUserFeedbackLeftCell : UITableViewCell
+@interface LCUserFeedbackLeftCell : LCUserFeedbackBaseCell
 
 @property(nonatomic, strong) UILabel *timestampLabel;
 

--- a/LeanCloudFeedback/LCUserFeedbackLeftCell.m
+++ b/LeanCloudFeedback/LCUserFeedbackLeftCell.m
@@ -24,7 +24,7 @@
         if ([[UIDevice currentDevice].systemVersion floatValue] < 7.0f) {
             self.textLabel.backgroundColor = [UIColor whiteColor];
         }
-        self.textLabel.font = [UIFont systemFontOfSize:12.0f];
+        self.textLabel.font = [[LCUserFeedbackBaseCell appearance] cellFont];
         self.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
         self.textLabel.numberOfLines = 0;
         self.textLabel.textAlignment = UITextAlignmentLeft;
@@ -58,7 +58,7 @@
     textLabelFrame.origin.x = 18;
     textLabelFrame.size.width = 226;
     
-    CGSize labelSize = [self.textLabel.text sizeWithFont:[UIFont systemFontOfSize:12.0f]
+    CGSize labelSize = [self.textLabel.text sizeWithFont:[[LCUserFeedbackBaseCell appearance] cellFont]
                                        constrainedToSize:CGSizeMake(226.0f, MAXFLOAT)
                                            lineBreakMode:NSLineBreakByWordWrapping];
     

--- a/LeanCloudFeedback/LCUserFeedbackRightCell.h
+++ b/LeanCloudFeedback/LCUserFeedbackRightCell.h
@@ -5,9 +5,9 @@
 //  Copyright (c) 2014 LeanCloud. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import "LCUserFeedbackBaseCell.h"
 
-@interface LCUserFeedbackRightCell : UITableViewCell
+@interface LCUserFeedbackRightCell : LCUserFeedbackBaseCell
 
 @property(nonatomic, strong) UILabel *timestampLabel;
 

--- a/LeanCloudFeedback/LCUserFeedbackRightCell.m
+++ b/LeanCloudFeedback/LCUserFeedbackRightCell.m
@@ -27,7 +27,7 @@
             self.textLabel.backgroundColor = [UIColor whiteColor];
         }
         
-        self.textLabel.font = [UIFont systemFontOfSize:12.0f];
+        self.textLabel.font = [[[LCUserFeedbackBaseCell class] appearance] cellFont];
         self.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
         self.textLabel.numberOfLines = 0;
         self.textLabel.textAlignment = UITextAlignmentLeft;
@@ -67,7 +67,7 @@
     textLabelFrame.size.width = 226;
     self.textLabel.frame = textLabelFrame;
     
-    CGSize labelSize = [self.textLabel.text sizeWithFont:[UIFont systemFontOfSize:12.0f]
+    CGSize labelSize = [self.textLabel.text sizeWithFont:[[[LCUserFeedbackBaseCell class] appearance] cellFont]
                                        constrainedToSize:CGSizeMake(226, MAXFLOAT)
                                            lineBreakMode:NSLineBreakByWordWrapping];
     

--- a/LeanCloudFeedback/LCUserFeedbackViewController.h
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.h
@@ -20,9 +20,9 @@ typedef enum : NSUInteger {
 @property(nonatomic, assign) LCUserFeedbackNavigationBarStyle navigationBarStyle;
 
 /**
- *  是否显示联系方式表头, 默认显示。假如不需要用户提供联系方式则可以不显示。
+ *  是否隐藏联系方式表头, 默认不隐藏。假如不需要用户提供联系方式则可以隐藏。
  */
-@property(nonatomic, assign) BOOL showContactInputHeader;
+@property(nonatomic, assign) BOOL contactHeaderHidden;
 
 /**
  *  设置字体。默认是大小为 16 的系统字体。

--- a/LeanCloudFeedback/LCUserFeedbackViewController.h
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.h
@@ -24,6 +24,11 @@ typedef enum : NSUInteger {
  */
 @property(nonatomic, assign) BOOL showContactInputHeader;
 
+/**
+ *  设置字体。默认是大小为 16 的系统字体。
+ */
+@property(nonatomic, strong) UIFont *feedbackCellFont;
+
 @property(nonatomic, retain) NSString *feedbackTitle;
 @property(nonatomic, retain) NSString *contact;
 

--- a/LeanCloudFeedback/LCUserFeedbackViewController.h
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.h
@@ -7,7 +7,22 @@
 
 #import <UIKit/UIKit.h>
 
+typedef enum : NSUInteger {
+    LCUserFeedbackNavigationBarStyleBlue = 0,
+    LCUserFeedbackNavigationBarStyleNone,
+} LCUserFeedbackNavigationBarStyle;
+
 @interface LCUserFeedbackViewController : UIViewController
+
+/**
+ *  导航栏主题，默认是蓝色主题
+ */
+@property(nonatomic, assign) LCUserFeedbackNavigationBarStyle navigationBarStyle;
+
+/**
+ *  是否显示联系方式表头, 默认显示。假如不需要用户提供联系方式则可以不显示。
+ */
+@property(nonatomic, assign) BOOL showContactInputHeader;
 
 @property(nonatomic, retain) NSString *feedbackTitle;
 @property(nonatomic, retain) NSString *contact;

--- a/LeanCloudFeedback/LCUserFeedbackViewController.m
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.m
@@ -42,7 +42,7 @@
     if (self) {
         // Custom initialization
         self.navigationBarStyle = LCUserFeedbackNavigationBarStyleBlue;
-        self.showContactInputHeader = YES;
+        self.contactHeaderHidden = NO;
         self.feedbackCellFont = [UIFont systemFontOfSize:16];
     }
     return self;
@@ -349,10 +349,10 @@
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
-    if (self.showContactInputHeader) {
-        return 48;
-    } else {
+    if (self.contactHeaderHidden) {
         return 0;
+    } else {
+        return 48;
     }
 }
 

--- a/LeanCloudFeedback/LCUserFeedbackViewController.m
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.m
@@ -43,6 +43,7 @@
         // Custom initialization
         self.navigationBarStyle = LCUserFeedbackNavigationBarStyleBlue;
         self.showContactInputHeader = YES;
+        self.feedbackCellFont = [UIFont systemFontOfSize:16];
     }
     return self;
 }
@@ -130,6 +131,8 @@
     [self.sendButton setBackgroundColor:[UIColor colorWithRed:247.0f/255 green:248.0f/255 blue:248.0f/255 alpha:1]];
     [self.sendButton addTarget:self action:@selector(sendButtonClicked:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:_sendButton];
+
+    [[[LCUserFeedbackBaseCell class] appearance] setCellFont:self.feedbackCellFont];
     
     _refreshControl = [[UIRefreshControl alloc] init];
     [_refreshControl addTarget:self action:@selector(handleRefresh:) forControlEvents:UIControlEventValueChanged];

--- a/LeanCloudFeedback/LCUserFeedbackViewController.m
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.m
@@ -41,6 +41,8 @@
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
         // Custom initialization
+        self.navigationBarStyle = LCUserFeedbackNavigationBarStyleBlue;
+        self.showContactInputHeader = YES;
     }
     return self;
 }
@@ -85,13 +87,20 @@
     UIBarButtonItem *closeButtonItem = [[UIBarButtonItem alloc] initWithCustomView:closeButton];
     self.navigationItem.leftBarButtonItem = closeButtonItem;
     [self.navigationItem setTitle:@"意见反馈"];
-    [self.navigationController.navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName : [UIColor whiteColor]}];
-    if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
-        [self.navigationController.navigationBar setBackgroundColor:[UIColor colorWithRed:85.0f/255 green:184.0f/255 blue:244.0f/255 alpha:1]];
-    } else {
-        [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:85.0f/255 green:184.0f/255 blue:244.0f/255 alpha:1]];
+    switch (self.navigationBarStyle) {
+        case LCUserFeedbackNavigationBarStyleBlue:
+            [self.navigationController.navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName : [UIColor whiteColor]}];
+            if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
+                [self.navigationController.navigationBar setBackgroundColor:[UIColor colorWithRed:85.0f/255 green:184.0f/255 blue:244.0f/255 alpha:1]];
+            } else {
+                [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:85.0f/255 green:184.0f/255 blue:244.0f/255 alpha:1]];
+            }
+            break;
+        case LCUserFeedbackNavigationBarStyleNone:
+            break;
+        default:
+            break;
     }
-    
     self.tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.frame), CGRectGetHeight(self.view.frame) - 48)
                                                   style:UITableViewStylePlain];
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
@@ -337,7 +346,11 @@
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
-    return 48;
+    if (self.showContactInputHeader) {
+        return 48;
+    } else {
+        return 0;
+    }
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {


### PR DESCRIPTION
```objc
/**
 *  导航栏主题，默认是蓝色主题
 */
@property(nonatomic, assign) LCUserFeedbackNavigationBarStyle navigationBarStyle;

/**
 *  是否隐藏联系方式表头, 默认不隐藏。假如不需要用户提供联系方式则可以隐藏。
 */
@property(nonatomic, assign) BOOL contactHeaderHidden;

/**
 *  设置字体。默认是大小为 16 的系统字体。
 */
@property(nonatomic, strong) UIFont *feedbackCellFont;
```

