### PR TITLE
记录 feedback 的 uid

### DIFF
--- a/LeanCloudFeedback/LCHttpClient.m
+++ b/LeanCloudFeedback/LCHttpClient.m
@@ -45,14 +45,18 @@
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method path:(NSString *)path parameters:(NSDictionary *)parameters {
     NSURL *url = [NSURL URLWithString:path relativeToURL:self.baseURL];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
-    [request setValue:[AVOSCloud getApplicationId] forHTTPHeaderField:@"X-AVOSCloud-Application-Id"];
+    [request setValue:[AVOSCloud getApplicationId] forHTTPHeaderField:@"X-LC-Id"];
     
     NSString *timestamp=[NSString stringWithFormat:@"%.0f",1000*[[NSDate date] timeIntervalSince1970]];
     NSString *sign=[LCUtils calMD5:[NSString stringWithFormat:@"%@%@",timestamp,[AVOSCloud getClientKey]]];
     NSString *headerValue=[NSString stringWithFormat:@"%@,%@",sign,timestamp];
-    [request setValue:headerValue forHTTPHeaderField:@"X-AVOSCloud-Request-Sign"];
+    [request setValue:headerValue forHTTPHeaderField:@"X-LC-Sign"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
     
-//    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    if ([AVUser currentUser].sessionToken) {
+        [request setValue:[AVUser currentUser].sessionToken forHTTPHeaderField:@"X-LC-Session"];
+    }
+    
     [request setTimeoutInterval:kAVDefaultNetworkTimeoutInterval];
     [request setHTTPMethod:method];
     if ([method isEqualToString:@"GET"] || [method isEqualToString:@"DELETE"]) {

--- a/LeanCloudFeedback/LCUserFeedbackThread.m
+++ b/LeanCloudFeedback/LCUserFeedbackThread.m
@@ -36,13 +36,6 @@ static NSString *const kLCUserFeedbackObjectId = @"LCUserFeedbackObjectId";
     return [NSString stringWithFormat:@"%@/%@/threads", LC_FEEDBACK_BASE_PATH, self.objectId];
 }
 
-- (instancetype)init {
-    if ((self = [super init])) {
-        self.iid = [AVInstallation currentInstallation].objectId;
-    }
-    return self;
-}
-
 -(NSMutableDictionary *)postData {
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
     


### PR DESCRIPTION
加上 X-LC-Session 请求头后，服务器会从中读取user.objectId ，后台即可看到 user.objectId。
 
![image](https://cloud.githubusercontent.com/assets/5022872/9843234/e35c15a6-5aea-11e5-9dbe-4571d578b4a4.png)

fix https://github.com/leancloud/leancloud-feedback-ios/issues/27

@tang3w 