### PR TITLE
修复集成到现有 Nav 结构返回按钮无响应问题

### DIFF
--- a/LeanCloudFeedback/LCUserFeedbackAgent.m
+++ b/LeanCloudFeedback/LCUserFeedbackAgent.m
@@ -33,6 +33,7 @@
     LCUserFeedbackViewController *feedbackViewController = [[LCUserFeedbackViewController alloc] init];
     feedbackViewController.feedbackTitle = title;
     feedbackViewController.contact = contact;
+    feedbackViewController.presented = YES;
     
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:feedbackViewController];
     [viewController presentViewController:navigationController animated:YES completion:^{

--- a/LeanCloudFeedback/LCUserFeedbackAgent.m
+++ b/LeanCloudFeedback/LCUserFeedbackAgent.m
@@ -33,7 +33,6 @@
     LCUserFeedbackViewController *feedbackViewController = [[LCUserFeedbackViewController alloc] init];
     feedbackViewController.feedbackTitle = title;
     feedbackViewController.contact = contact;
-    feedbackViewController.presented = YES;
     
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:feedbackViewController];
     [viewController presentViewController:navigationController animated:YES completion:^{

--- a/LeanCloudFeedback/LCUserFeedbackViewController.h
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.h
@@ -33,7 +33,7 @@ typedef enum : NSUInteger {
 @property(nonatomic, copy) NSString *contact;
 
 /**
- *  是否使用的 present 方式弹出。决定返回按钮样式和返回方式
+ *  是否使用的 present 方式弹出。默认为YES，决定返回按钮样式和返回方式
  */
 @property(nonatomic, assign) BOOL presented;
 

--- a/LeanCloudFeedback/LCUserFeedbackViewController.h
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.h
@@ -32,4 +32,9 @@ typedef enum : NSUInteger {
 @property(nonatomic, copy) NSString *feedbackTitle;
 @property(nonatomic, copy) NSString *contact;
 
+/**
+ *  是否使用的 present 方式弹出。决定返回按钮样式和返回方式
+ */
+@property(nonatomic, assign) BOOL presented;
+
 @end

--- a/LeanCloudFeedback/LCUserFeedbackViewController.m
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.m
@@ -80,10 +80,11 @@ static CGFloat const kSendButtonWidth = 60;
 }
 
 - (void)setupUI {
-    self.navigationItem.leftBarButtonItem = self.closeButtonItem;
+    if (self.presented) {
+        self.navigationItem.leftBarButtonItem = self.closeButtonItem;
+    }
+    
     [self.navigationItem setTitle:@"意见反馈"];
-    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:self action:nil];
-    self.navigationItem.backBarButtonItem = backButton;
     [self setupNavigaionBar];
     
     [self.view addSubview:self.tableView];
@@ -113,9 +114,14 @@ static CGFloat const kSendButtonWidth = 60;
 
 - (UIBarButtonItem *)closeButtonItem {
     if (_closeButtonItem == nil) {
-        UIButton *closeButton = [self closeButton];
-        [closeButton addTarget:self action:@selector(closeButtonClicked:) forControlEvents:UIControlEventTouchUpInside];
-         _closeButtonItem = [[UIBarButtonItem alloc] initWithCustomView:closeButton];
+        if (self.presented) {
+            _closeButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemStop target:self action:@selector(closeButtonClicked:)];
+        }else{
+            UIButton *closeButton = [self closeButton];
+            [closeButton addTarget:self action:@selector(closeButtonClicked:) forControlEvents:UIControlEventTouchUpInside];
+            _closeButtonItem = [[UIBarButtonItem alloc] initWithCustomView:closeButton];
+        }
+
     }
     return _closeButtonItem;
 }
@@ -179,12 +185,8 @@ static CGFloat const kSendButtonWidth = 60;
         case LCUserFeedbackNavigationBarStyleBlue: {
             [self.navigationController.navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName : [UIColor whiteColor]}];
             UIColor *blue =[UIColor colorWithRed:85.0f/255 green:184.0f/255 blue:244.0f/255 alpha:1];
-            if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
-                self.navigationController.navigationBar.tintColor = blue;
-            } else {
-                self.navigationController.navigationBar.barTintColor = blue;
-                self.navigationController.navigationBar.tintColor = blue;
-            }
+            self.navigationController.navigationBar.barTintColor = blue;
+            self.closeButtonItem.tintColor = [UIColor whiteColor];
             break;
         }
         case LCUserFeedbackNavigationBarStyleNone:

--- a/LeanCloudFeedback/LCUserFeedbackViewController.m
+++ b/LeanCloudFeedback/LCUserFeedbackViewController.m
@@ -54,6 +54,7 @@ static CGFloat const kSendButtonWidth = 60;
         self.navigationBarStyle = LCUserFeedbackNavigationBarStyleBlue;
         self.contactHeaderHidden = NO;
         self.feedbackCellFont = [UIFont systemFontOfSize:16];
+        self.presented = YES;
     }
     return self;
 }


### PR DESCRIPTION
现在可以在已存在的 UINavigationController 结构下直接进行 Push 操作，并能继承已有的 Nav 自定义样式。

如果想以 Present 方式弹出，需要给 `LCUserFeedbackViewController` 的 `presented ` 属性设置成 **YES**，然后返回按钮会用 UIBarButtonSystemItemStop 样式。

如果不设 `presented ` 属性且在 Nav 中，则继承所属 Nav 原有默认的样式和返回操作(pop)。